### PR TITLE
Add self--help utility

### DIFF
--- a/bin/color
+++ b/bin/color
@@ -1,15 +1,18 @@
 #!/bin/sh
+# --help
 # Its like grep but doesn't filter out lines & each search term gets its own color!
-#
+#  
 # Example usages:
-#   while date; do sleep 1; done |                               color '^[A-Z][a-z][a-z]'            ' [A-Z][a-z][a-z]'  ':[0-9][0-9]:' '[0-9]'{0..9}' '
-#   while date; do sleep 1; done |                               color '^[A-Z][a-z][a-z]' SKIP_GREEN ' [A-Z][a-z][a-z]'  ':[0-9][0-9]:' '[0-9]'{0..9}' '
-#   while date; do sleep 1; done |                      COLOR=42 color '^[A-Z][a-z][a-z]'            ' [A-Z][a-z][a-z]'  ':[0-9][0-9]:' '[0-9]'{0..9}' '
-#   while date; do sleep 1; done | COLOR_EFFECTS="3;4;" COLOR=42 color '^[A-Z][a-z][a-z]'            ' [A-Z][a-z][a-z]'  ':[0-9][0-9]:' '[0-9]'{0..9}' '
+#  * echo hello world             |                               color he                 wo         lo
+#  * while date; do sleep 1; done |                               color '^[A-Z][a-z][a-z]'            ' [A-Z][a-z][a-z]'  ':[0-9][0-9]:' '[0-9]'{0..9}' '
+#  * while date; do sleep 1; done |                               color '^[A-Z][a-z][a-z]' SKIP_GREEN ' [A-Z][a-z][a-z]'  ':[0-9][0-9]:' '[0-9]'{0..9}' '
+#  * while date; do sleep 1; done |                      COLOR=42 color '^[A-Z][a-z][a-z]'            ' [A-Z][a-z][a-z]'  ':[0-9][0-9]:' '[0-9]'{0..9}' '
+#  * while date; do sleep 1; done | COLOR_EFFECTS="3;4;" COLOR=42 color '^[A-Z][a-z][a-z]'            ' [A-Z][a-z][a-z]'  ':[0-9][0-9]:' '[0-9]'{0..9}' '
+self--help "$0" "$@" && exit
 
 COLOR=${COLOR:-31}                 # Defaults to red
 COLOR_EFFECTS=${COLOR_EFFECTS:-1;} # Defaults to bold
-SKIP_COLORS=${SKIP_COLORS:-"$(seq --separator=' ' 37 40) $(seq --separator=' ' 47 90) 98 99 103"}
+SKIP_COLORS=${SKIP_COLORS:-"$(seq -s' ' 37 40) $(seq -s' ' 47 90) 98 99 103"}
 MAX_COLOR=${MAX_COLOR:-106}
 MIN_COLOR=${MIN_COLOR:-$COLOR}
 

--- a/bin/self--help
+++ b/bin/self--help
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+markdown_highlighter() {
+  if command -v bat > /dev/null 2>&1; then
+    echo "bat --color=always --style=${BAT_STYLE:-plain} --language=markdown"
+  else
+    echo cat
+  fi
+}
+
+script="$1"; shift
+
+[ "$1" = --help ] ||
+[ "$1" = -h     ] && {
+  printf "[1m%s[0m\n\n" "$(basename "$script")"
+
+  sed -n -e '/^# --help$/,/^$/{/^# --help$/d;/^self--help/d;p;}' < "$script"  |
+    # strip blank lines & stuff
+    sed -e :a -e 's/^# //g' -e '/^\n*$/{$d;N;};/\n$/ba' |
+      ${MARKDOWN:=$(markdown_highlighter)}
+}

--- a/shpecs/color_shpec.sh
+++ b/shpecs/color_shpec.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env shpec
+source shpecs/shpec_helper.sh
+
+describe "color"
+  matches_expected 'color --help' \
+<<-EOF
+color
+
+Its like grep but doesn't filter out lines & each search term gets its own color!
+
+Example usages:
+ * echo hello world             |                               color he                 wo         lo
+ * while date; do sleep 1; done |                               color '^[A-Z][a-z][a-z]'            ' [A-Z][a-z][a-z]'  ':[0-9][0-9]:' '[0-9]'{0..9}' '
+ * while date; do sleep 1; done |                               color '^[A-Z][a-z][a-z]' SKIP_GREEN ' [A-Z][a-z][a-z]'  ':[0-9][0-9]:' '[0-9]'{0..9}' '
+ * while date; do sleep 1; done |                      COLOR=42 color '^[A-Z][a-z][a-z]'            ' [A-Z][a-z][a-z]'  ':[0-9][0-9]:' '[0-9]'{0..9}' '
+ * while date; do sleep 1; done | COLOR_EFFECTS="3;4;" COLOR=42 color '^[A-Z][a-z][a-z]'            ' [A-Z][a-z][a-z]'  ':[0-9][0-9]:' '[0-9]'{0..9}' '
+EOF
+
+  matches_expected_with_colors 'echo hello world | color he wo lo' \
+<<-EOF
+[1;31m[Khe[m[Kl[1;33m[Klo[m[K [1;32m[Kwo[m[Krld
+EOF
+end

--- a/shpecs/shpec_helper.sh
+++ b/shpecs/shpec_helper.sh
@@ -42,6 +42,7 @@ xmatches_expected() { local cmd="${cmd:-$1}"
   end
 }
 
+# Darwin is adding some weird ^[k control characters with grep's colors that aren't on linux
 xmatches_expected_with_colors() {
   xmatches_expected "$@"
 }


### PR DESCRIPTION
Provides a basic `--help` option to scripts that include the lines:
`my_script`
```
# --help
# Example usages:
#  * my_script foo
#  * my_script bar
#
# and then...
self--help "$0" "$@" && exit
```

When invoked with:
`my_script --help`

Will output
```
my_script

Example usages:
 * my_script foo
 * my_script bar

and then...
```