### PR TITLE
Json2table/truncated cols

### DIFF
--- a/bin/jsonl2tsv
+++ b/bin/jsonl2tsv
@@ -9,40 +9,57 @@ arg_boolean headers     ${headers:-true}
 
 
 __JQ__
+def truncate(max; end_size):
+  (if end_size then end_size else 3 end) as $end_size |
+
+  if max and (.|length) > (max - 3) then "\(.[0:(max-$end_size-3)])...\(.[-$end_size:])" else . end;
 
 
-( $cols     | map(. | split(":")[ 0]                  )) as $keys       |
-( $cols     | map(. | split(".")[-1] | split(":")[-1] )) as $headings   |
+def dig(key):
+  reduce (key | split("."))[] as $subkey (
+    .;
+    if type == "object" and has($subkey) then
+      .[$subkey]
+    else
+      $missing_key
+    end
+  );
 
-(
-  if $headers and (input_line_number < 2) then
-    # if the key matches the heading then use the heading
-    # else prepend : to the heading
-    [ $keys, $headings ] |
-      transpose |
-      map(
-      if .[0] == .[1] then
-        .[1]
-      else
-        ":\(.[1])"
-      end
-    )
+
+def key_value_for(row):
+  # split the input key into key & max value length
+#  ( . | split("%")                           ) as [$key, $max_str] |
+#  ( $max_str | if . then tonumber else . end ) as $max             |
+  ( . | split("%")                                                 ) as [$key, $truncation_cmd   ] |
+  ( $truncation_cmd // "" | split(",")                             ) as [$max_str, $end_size_str ] |
+  ( [$max_str, $end_size_str] | map(if . then tonumber else . end) ) as [$max, $end_size         ] |
+
+  row | dig($key) | tostring | truncate($max; $end_size);
+
+def show_heading(key; heading):
+  if heading == (key|split("%")[0]) then
+    heading
   else
-    empty
-  end
-),
-(
+    ":\(heading)"
+  end;
+
+
+def header(keys; headings):
+  [ keys, headings ] | transpose |
+  map(show_heading(.[0];.[1]));
+
+
+def show_header(keys; headings):
+  if $headers and (input_line_number < 2) then header(keys; headings) else empty end;
+
+
+def show_rows(keys):
   . as $row |
-  (
-    $keys |
-    map(
-      ( . | split(".") ) as $subkeys                  |  # split the col name on "." & into subkeys
-      reduce $subkeys[] as $subkey (
-        $row;
-        if type == "object" and has($subkey) then .[$subkey] else $missing_key end
-      )                                               |  # dive deeper into the row by reducing with subkeys
-      tostring
-    )                                                    # pull out each col from each row and convert to string
-  )
-) |
-@tsv                                                     # convert to tsv
+  keys | map(key_value_for($row));
+
+
+( $cols | map(. | split(":")[ 0]                                 )) as $keys        |
+( $cols | map(. | split(".")[-1] | split(":")[-1] | split("%")[0])) as $headings    |
+( $cols | map(. | split("%")[-1]                                 )) as $truncations |
+
+show_header($keys; $headings), show_rows($keys) | @tsv

--- a/shpecs/json2table_shpec.sh
+++ b/shpecs/json2table_shpec.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env shpec
 # shellcheck disable=SC1090,SC1091,SC2016
 source "${BASH_SOURCE[0]%/*}/shpec_helper.sh"
+export input_cmd input_file
 
 
 describe "json2table"
-  export input_file='shpecs/support/super_heroes.json'
+  input_file='shpecs/support/super_heroes.json'
 
   describe 'processing `.json` files'
-    export input_cmd='jq --compact-output ".members"'
+    input_cmd='jq --compact-output ".members"'
 
     describe 'cols'
       describe 'all'
@@ -59,6 +60,19 @@ EOF
 │Madame Uppercut│Jane Wilson     │
 │Eternal Flame  │Unknown         │
 └───────────────┴────────────────┘
+EOF
+      end
+
+      describe 'using truncation'
+        matches_expected 'cols="name powers%30" json2table' \
+<<-EOF
+┌───────────────┬──────────────────────────────┐
+│name           │powers                        │
+├───────────────┼──────────────────────────────┤
+│Molecule Man   │["Radiation resistance",...t"]│
+│Madame Uppercut│["Million tonne punch","...s"]│
+│Eternal Flame  │["Immortality","Heat Imm...l"]│
+└───────────────┴──────────────────────────────┘
 EOF
       end
     end

--- a/shpecs/json2table_shpec.sh
+++ b/shpecs/json2table_shpec.sh
@@ -1,15 +1,56 @@
 #!/usr/bin/env shpec
-source shpecs/shpec_helper.sh
+# shellcheck disable=SC1090,SC1091,SC2016
+source "${BASH_SOURCE[0]%/*}/shpec_helper.sh"
 
 
 describe "json2table"
-  input_file='shpecs/support/super_heroes.json'
+  export input_file='shpecs/support/super_heroes.json'
 
   describe 'processing `.json` files'
-    input_cmd='jq --compact-output ".members"'
+    export input_cmd='jq --compact-output ".members"'
 
     describe 'cols'
-      matches_expected 'cols="name secretIdentity:secret_identity" json2table' \
+      describe 'all'
+        matches_expected 'json2table' \
+<<-EOF
+┌───────┬──────┬───────────────┬───────────────────────────────────────────────────────────────────────────────────┬──────────────┐
+│age    │gender│name           │powers                                                                             │secretIdentity│
+├───────┼──────┼───────────────┼───────────────────────────────────────────────────────────────────────────────────┼──────────────┤
+│29     │male  │Molecule Man   │["Radiation resistance","Turning tiny","Radiation blast"]                          │Dan Jukes     │
+│39     │female│Madame Uppercut│["Million tonne punch","Damage resistance","Superhuman reflexes"]                  │Jane Wilson   │
+│1000000│female│Eternal Flame  │["Immortality","Heat Immunity","Inferno","Teleportation","Interdimensional travel"]│Unknown       │
+└───────┴──────┴───────────────┴───────────────────────────────────────────────────────────────────────────────────┴──────────────┘
+EOF
+      end
+
+      describe 'some'
+        matches_expected 'json2table age name' \
+<<-EOF
+┌───────┬───────────────┐
+│age    │name           │
+├───────┼───────────────┤
+│29     │Molecule Man   │
+│39     │Madame Uppercut│
+│1000000│Eternal Flame  │
+└───────┴───────────────┘
+EOF
+      end
+
+      describe 'using an env var'
+        matches_expected 'cols="name secretIdentity" json2table' \
+<<-EOF
+┌───────────────┬──────────────┐
+│name           │secretIdentity│
+├───────────────┼──────────────┤
+│Molecule Man   │Dan Jukes     │
+│Madame Uppercut│Jane Wilson   │
+│Eternal Flame  │Unknown       │
+└───────────────┴──────────────┘
+EOF
+      end
+
+      describe 'using an alias'
+        matches_expected 'cols="name secretIdentity:secret_identity" json2table' \
 <<-EOF
 ┌───────────────┬────────────────┐
 │name           │:secret_identity│
@@ -19,6 +60,7 @@ describe "json2table"
 │Eternal Flame  │Unknown         │
 └───────────────┴────────────────┘
 EOF
+      end
     end
   end
 

--- a/shpecs/jsonl2tsv_shpec.sh
+++ b/shpecs/jsonl2tsv_shpec.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env shpec
-source shpecs/shpec_helper.sh
+# shellcheck disable=SC1090,SC1091,SC2016
+source "${BASH_SOURCE[0]%/*}/shpec_helper.sh"
+export input_cmd input_file
+
 
 describe "jsonl2tsv"
   input_file='shpecs/support/super_heroes.json'
@@ -24,11 +27,42 @@ Madame Uppercut	39	["Million tonne punch","Damage resistance","Superhuman reflex
 Eternal Flame	1000000	["Immortality","Heat Immunity","Inferno","Teleportation","Interdimensional travel"]
 EOF
 
-    matches_expected 'headers=false jsonl2tsv name age powers' \
+    describe 'with no headers'
+      matches_expected 'headers=false jsonl2tsv name age powers' \
 <<-EOF
 Molecule Man	29	["Radiation resistance","Turning tiny","Radiation blast"]
 Madame Uppercut	39	["Million tonne punch","Damage resistance","Superhuman reflexes"]
 Eternal Flame	1000000	["Immortality","Heat Immunity","Inferno","Teleportation","Interdimensional travel"]
 EOF
+    end
+
+    describe 'truncation'
+      matches_expected 'jsonl2tsv name age powers%30' \
+<<-EOF
+name	age	powers
+Molecule Man	29	["Radiation resistance",...t"]
+Madame Uppercut	39	["Million tonne punch","...s"]
+Eternal Flame	1000000	["Immortality","Heat Imm...l"]
+EOF
+
+      describe 'with end_size'
+        matches_expected 'jsonl2tsv name age powers%30,7' \
+<<-EOF
+name	age	powers
+Molecule Man	29	["Radiation resistan...blast"]
+Madame Uppercut	39	["Million tonne punc...lexes"]
+Eternal Flame	1000000	["Immortality","Heat...ravel"]
+EOF
+
+      describe 'with alias'
+        matches_expected 'jsonl2tsv name age powers%30,7:PoWeRZ' \
+<<-EOF
+name	age	:PoWeRZ
+Molecule Man	29	["Radiation resistan...blast"]
+Madame Uppercut	39	["Million tonne punc...lexes"]
+Eternal Flame	1000000	["Immortality","Heat...ravel"]
+EOF
+      end
+    end
   end
 end


### PR DESCRIPTION
### Example usage:
` json2table name powers%30`
```
┌───────────────┬──────────────────────────────┐
│name           │powers                        │
├───────────────┼──────────────────────────────┤
│Molecule Man   │["Radiation resistance",...t"]│
│Madame Uppercut│["Million tonne punch","...s"]│
│Eternal Flame  │["Immortality","Heat Imm...l"]│
└───────────────┴──────────────────────────────┘
```