### PR TITLE
feat: Allow adjustable truncation end_size

### DIFF
--- a/shpecs/json2table_shpec.sh
+++ b/shpecs/json2table_shpec.sh
@@ -74,6 +74,17 @@ EOF
 │Eternal Flame  │["Immortality","Heat Immu..."]│
 └───────────────┴──────────────────────────────┘
 EOF
+
+        matches_expected 'json2table name powers%30,10' \
+<<-EOF
+┌───────────────┬──────────────────────────────┐
+│name           │powers                        │
+├───────────────┼──────────────────────────────┤
+│Molecule Man   │["Radiation resis...on blast"]│
+│Madame Uppercut│["Million tonne p...reflexes"]│
+│Eternal Flame  │["Immortality","H...l travel"]│
+└───────────────┴──────────────────────────────┘
+EOF
       end
 
       describe 'using max_width'


### PR DESCRIPTION
`json2table name powers%30,10'`
```
┌───────────────┬──────────────────────────────┐
│name           │powers                        │
├───────────────┼──────────────────────────────┤
│Molecule Man   │["Radiation resis...on blast"]│
│Madame Uppercut│["Million tonne p...reflexes"]│
│Eternal Flame  │["Immortality","H...l travel"]│
└───────────────┴──────────────────────────────┘
```