### PR TITLE
refactor: speed up color

### DIFF
--- a/bin/bash--script
+++ b/bin/bash--script
@@ -15,9 +15,11 @@ timestamp() {
 
 info() {
   color="${color:-34}"
+  ifs0="$IFS"; IFS=""
   while read -r line; do
     >&2 echo -e "$(${return_cursor:-false} && printf "\r")[$(timestamp)] [${color}m${line}[0m"
   done < <(echo -e "$@")
+  IFS="$ifs0"
 }
 
 info_r() {

--- a/bin/color
+++ b/bin/color
@@ -24,7 +24,7 @@ next_color() {
     color=$((color+1))
   done
 
-  [ "$color" -gt "$MAX_COLOR" ] && echo "$MIN_COLOR" || echo "$color"
+  [ "$color" -lt "$MAX_COLOR" ] && echo "$color"
 }
 
 color() { pattern="${1:-}"
@@ -32,11 +32,72 @@ color() { pattern="${1:-}"
   if [ $# -gt 0 ]; then
     GREP_COLOR="${COLOR_EFFECTS}${COLOR}" grep -E --color=always --line-buffered "${pattern}|$" | {
       shift
-      COLOR="$(next_color "$COLOR")" color "$@"
+      COLOR="$(next_color "$COLOR" || echo "$MIN_COLOR")" color "$@"
     }
   else
     cat
   fi
 }
 
-color "$@"
+color_count() {
+  # Nb. currently there's only `25` colors, but lets figure it out dynamically in case our code changes...
+  local colors=("$COLOR")
+  while COLOR="$(next_color "$COLOR")"; do
+    colors+=("$COLOR")
+  done
+  echo $((${#colors[@]} + 1))
+}
+
+
+# From ChatGPT (2024-04-22)...
+# Given arguments
+# eg.
+# ```
+# foo bar baz biz buz goo gar giz guz
+# ```
+# Group them together based on a COUNT
+# So,
+# * `COUNT=3`
+# ```
+# (foo|bar|baz) (biz|buz|goo) (gar|giz|guz)
+# ```
+# * `COUNT=2`
+# ```
+# (foo|baz|buz|gar|guz) (bar|biz|goo|giz)
+# ```
+# * `COUNT=1`
+# ```
+# (foo|bar|baz|biz|buz|goo|gar|giz|guz)
+# ```
+color_grouped() { local args=("$@")
+  COLOR_COUNT=${COLOR_COUNT:-$(color_count)}
+
+  # Initialize arrays for groups
+  declare -a groups
+
+  # Calculate the length of args array
+  args_length=${#args[@]}
+
+  # Distribute arguments into groups based on COUNT
+  for (( i=0; i<args_length; i++ )); do
+    local group_index=$((i % COLOR_COUNT))
+    if [ -z "${groups[group_index]:-}" ]; then
+      groups[group_index]="${args[i]}"
+    else
+      groups[group_index]+="|${args[i]}"
+    fi
+  done
+
+  # put surrounding braces around the groups
+  for (( i=0; i<COLOR_COUNT; i++ )); do
+    if [ -n "${groups[i]:-}" ]; then
+      groups[i]="(${groups[i]})"
+    fi
+  done
+
+  ${DEBUG:-false} && echo groups: "${groups[@]}"
+  color "${groups[@]}"
+}
+
+# color "$@"
+color_grouped "$@"

--- a/shpecs/color_shpec.sh
+++ b/shpecs/color_shpec.sh
@@ -4,7 +4,7 @@ source shpecs/shpec_helper.sh
 
 describe "color"
   matches_expected 'color --help' <<-EOF
-color (v2023.12.27)
+color (v2024.04.26)
 
 ## color
 

--- a/shpecs/json-redact_shpec.sh
+++ b/shpecs/json-redact_shpec.sh
@@ -6,7 +6,7 @@ describe "json-redact"
   input_file() { echo 'shpecs/support/super_heroes.json'; }
 
   matches_expected 'json-redact --help' <<-EOF
-json-redact (v2023.12.27)
+json-redact (v2024.04.26)
 
 ## json-redact
 

--- a/shpecs/json-remove-nulls_shpec.sh
+++ b/shpecs/json-remove-nulls_shpec.sh
@@ -5,7 +5,7 @@ source shpecs/shpec_helper.sh
 
 describe "json-remove-nulls"
   matches_expected 'json-remove-nulls --help' <<-EOF
-json-remove-nulls (v2023.12.27)
+json-remove-nulls (v2024.04.26)
 
 ## json-remove-nulls
 


### PR DESCRIPTION
### Verification

Test files:
 * a random string of `10000` characters
```
cat /dev/urandom | LC_ALL=C tr -dc 'a-z' | head -c 10000 > /tmp/random_chars.txt
```
 * a random list of `1000` 4-letter words to be used as color terms
 ```
 egrep '^[a-z]{4}$' /usr/share/dict/words | shuf -n 1000 > /tmp/random_words.txt
```
<img width="1675" alt="color_01" src="https://github.com/jq-sh/jq-sh/assets/49626717/538200f6-7a01-4b1a-8618-8419c21cf4fd">


#### Baseline tests:
Colorizing our list random of random words in the random chars...

##### First using the current implementation of `color`:
 * `cat /tmp/random_chars.txt | time color $(cat /tmp/random_words.txt)`
 -> `color $(cat /tmp/random_words.txt)  5.48s user 24.69s system 86% cpu 35.047 total`
<img width="1664" alt="Screenshot 2024-04-22 at 14 40 07" src="https://github.com/jq-sh/jq-sh/assets/49626717/9f58ccc7-2887-4ef9-b0ba-387e9443065d">


#####
 Then comparing that to just a single-color `grep`:
 * `cat /tmp/random_chars.txt | time grep -f <(cat /tmp/random_words.txt)`
 -> `grep --color=auto --exclude-dir={.bzr,CVS,.git,.hg,.svn,.idea,.tox} -f   1.65s user 0.00s system 98% cpu 1.682 total`
<img width="1665" alt="Screenshot 2024-04-22 at 14 40 36" src="https://github.com/jq-sh/jq-sh/assets/49626717/7b426675-3675-4989-902c-919baa25dc10">


ie. `24.69s` vs `1.65s (user)` - which shows quite an expensive overhead to pay for the pretty colors.

##### Then, after adding the regex color grouping in this PR:
 * `cat /tmp/random_chars.txt | time color $(cat /tmp/random_words.txt)`
  -> `color $(cat /tmp/random_words.txt)  0.28s user 0.40s system 54% cpu 1.252 total`
<img width="1669" alt="Screenshot 2024-04-22 at 14 40 57" src="https://github.com/jq-sh/jq-sh/assets/49626717/eb53ce38-0b82-479b-8ba0-4cd987348f6d">


##### And finally avoiding having to count the colors to get the COLOR_COUNT by hard-coding it...
 * `cat /tmp/random_chars.txt | time COLOR_COUNT=25 color $(cat /tmp/random_words.txt)`
    -> `COLOR_COUNT=25 color $(cat /tmp/random_words.txt)  0.24s user 0.22s system 91% cpu 0.512 total`
<img width="1670" alt="Screenshot 2024-04-22 at 14 41 17" src="https://github.com/jq-sh/jq-sh/assets/49626717/a6317f2d-5a15-4a10-b484-b06cd0772d9d">


(That looks like just a small saving... ie. from `0.28s (user)` compared to `0.25s (user)` ... so we probably won't bother - but worth leaving the option to do that there anyway so the counted number of colors can be overridden.)

#### Conclusion
 So in this particular test case with `1000` search terms that's a speed up of around 2 orders of magnitude.
 (ie. `25s` vs `0.28s`)
 And all while still keeping the pretty colors!
 <img alt="pretty colors" src="https://i.giphy.com/ruw1bRYN0IXNS.webp">