### PR TITLE
feat: add filters to json2table

### DIFF
--- a/bin/json2table
+++ b/bin/json2table
@@ -16,7 +16,9 @@ resource="${resource:-${_resource%.table}}"
 
 
 # Nb. `eval echo "$cols"` allows x.{y1,y2} expansion
-COLS=$(eval echo "${cols:-${@:-}}")
+# COLS=$(eval echo "${cols:-${@:-}}")
+
+COLS="${cols:-${@:-}}"
 SORT_BY=${sort_by:-}
 MISSING_KEY=${MISSING_KEY:-¿}
 TITLE=${title:-}
@@ -208,13 +210,7 @@ else
     # Nb. this is a jqsh script, but we can't do the jq in the
     # main jqsh script because...
     resource="$resource" json_objects_array                          |
-
-    # we need to pop out to bash to do the sorting
-    # ie. because it doesn't appear to be possible to
-    # pass a `sort_by` expression into jq
-    json-sort "${sort_by[@]:-}"                                      |
-
-    resource="$resource" title="$title" json2table.jqsh "${cols[@]:-}" |
+    sort_by="${sort_by[*]:-}" cols="${cols[*]}" resource="$resource" title="$title" json2table.jqsh |
 
     # TODO - reimplement the `color` in jq code,
     # so we don't have to pop back out to bash

--- a/bin/json2table.jqsh
+++ b/bin/json2table.jqsh
@@ -7,7 +7,7 @@ arg       resource     $resource
 arg       missing_key  ${missing_key:-¿}
 arg_int   max_width    ${max_width:-${COLUMNS:-0}}
 
-arg_array cols         ${cols:-$*}
+arg       cols         "${cols}"
 
 
 __JQ__

--- a/shpecs/color_shpec.sh
+++ b/shpecs/color_shpec.sh
@@ -4,7 +4,7 @@ source shpecs/shpec_helper.sh
 
 describe "color"
   matches_expected 'color --help' <<-EOF
-color (v2024.04.26)
+color (v2024.06.10)
 
 ## color
 

--- a/shpecs/color_shpec.sh
+++ b/shpecs/color_shpec.sh
@@ -4,7 +4,7 @@ source shpecs/shpec_helper.sh
 
 describe "color"
   matches_expected 'color --help' <<-EOF
-color (v2024.06.10)
+color (v2024.09.08)
 
 ## color
 

--- a/shpecs/json-redact_shpec.sh
+++ b/shpecs/json-redact_shpec.sh
@@ -6,7 +6,7 @@ describe "json-redact"
   input_file() { echo 'shpecs/support/super_heroes.json'; }
 
   matches_expected 'json-redact --help' <<-EOF
-json-redact (v2024.06.10)
+json-redact (v2024.09.08)
 
 ## json-redact
 

--- a/shpecs/json-redact_shpec.sh
+++ b/shpecs/json-redact_shpec.sh
@@ -6,7 +6,7 @@ describe "json-redact"
   input_file() { echo 'shpecs/support/super_heroes.json'; }
 
   matches_expected 'json-redact --help' <<-EOF
-json-redact (v2024.04.26)
+json-redact (v2024.06.10)
 
 ## json-redact
 

--- a/shpecs/json-remove-nulls_shpec.sh
+++ b/shpecs/json-remove-nulls_shpec.sh
@@ -5,7 +5,7 @@ source shpecs/shpec_helper.sh
 
 describe "json-remove-nulls"
   matches_expected 'json-remove-nulls --help' <<-EOF
-json-remove-nulls (v2024.06.10)
+json-remove-nulls (v2024.09.08)
 
 ## json-remove-nulls
 

--- a/shpecs/json-remove-nulls_shpec.sh
+++ b/shpecs/json-remove-nulls_shpec.sh
@@ -5,7 +5,7 @@ source shpecs/shpec_helper.sh
 
 describe "json-remove-nulls"
   matches_expected 'json-remove-nulls --help' <<-EOF
-json-remove-nulls (v2024.04.26)
+json-remove-nulls (v2024.06.10)
 
 ## json-remove-nulls
 

--- a/shpecs/jsont_shpec.sh
+++ b/shpecs/jsont_shpec.sh
@@ -12,23 +12,11 @@ describe "jsont"
     "homeTown": "Metro City",
     "secretBase": "Super tower"
   },
-  "members": [
-    {
-      "name": "Molecule Man",
-      "age": 30,
-      "gender": "male",
-      "secretIdentity": "Dan Jukes",
-      "powers": [
-        "Radiation resistance",
-        "Turning tiny",
-        "Radiation blast"
-      ]
-    }
-  ]
+  "members": []
 }
 EOF
 
-  matches_expected "formed=2015 squadName='Junior Super Heroes' active=false super_heroes.jsont 'member age=30' 'member age=31 name=Rubber\ Girl gender=female' | jq" <<-EOF
+  matches_expected "formed=2015 squadName='Junior Super Heroes' active=false super_heroes.jsont 'member age=30 gender=female' 'member age=31 name=Rubber\ Girl gender=female' | jq" <<-EOF
 {
   "squadName": "Junior Super Heroes",
   "active": false,
@@ -41,7 +29,7 @@ EOF
     {
       "name": "Molecule Man",
       "age": 30,
-      "gender": "male",
+      "gender": "female",
       "secretIdentity": "Dan Jukes",
       "powers": [
         "Radiation resistance",

--- a/shpecs/shpec_helper.sh
+++ b/shpecs/shpec_helper.sh
@@ -40,7 +40,7 @@ matches_expected_with_colors() {
 
 xmatches_expected() { local cmd="${cmd:-$1}"
   describe '`'"${cmd:-echo}"'`'
-    it 
+    it
       iecho "[33;1mpending[0m"
     end_
   end_

--- a/shpecs/support/super_heroes.jsont
+++ b/shpecs/support/super_heroes.jsont
@@ -6,8 +6,8 @@ arg_int     formed     "${formed:-2016}"
 arg         homeTown   "${homeTown:-Metro City}"
 arg         secretBase "${secretBase:-Super tower}"
 arg_jsonl   members     $(
-  for args in "${@:-}"; do
-    eval member.jsont $args
+  for member_args in "$@"; do
+    eval "member.jsont $member_args"
   done
 )
 


### PR DESCRIPTION
# Description

## Problem and Solution

### Problem
Previously, the `json2table` script lacked the capability to filter and sort JSON data based on specific columns. Users had to manually preprocess their JSON data before using `json2table`, which was inconvenient and error-prone.

### Solution
This PR introduces inline filtering and sorting features to the `json2table` script, allowing users to specify columns, apply filters, and sort data directly within the script. This enhancement simplifies data processing workflows and improves the usability of the `json2table` tool.

> [!NOTE]
> Filtering expressions support regex (e.g., `/pattern/`), comparison operators (e.g., `>`, `<`, `<=`, `>=`, `=`), and string matching. 

## Extended Filtering Examples from the Specs
Given
```json
[
  {
    "name": "Molecule Man",
    "age": 29,
    "gender": "male",
    "secret": {
      "identity": "Dan Jukes"
    },
    "powers": [
      "Radiation resistance",
      "Turning tiny",
      "Radiation blast"
    ]
  },
  {
    "name": "Madame Uppercut",
    "age": 39,
    "gender": "female",
    "secret": {
      "identity": "Jane Wilson"
    },
    "powers": [
      "Million tonne punch",
      "Damage resistance",
      "Superhuman reflexes"
    ]
  },
  {
    "name": "Eternal Flame",
    "age": 1000000,
    "gender": "female",
    "secret": {
      "identity": "Unknown"
    },
    "powers": [
      "Immortality",
      "Heat Immunity",
      "Inferno",
      "Teleportation",
      "Interdimensional travel"
    ]
  }
]
```

The following table can be created:
```
┌───────────────┬──────┬───┐
│name           │gender│age│
├───────────────┼──────┼───┤
│Madame Uppercut│female│39 │
│Molecule Man   │male  │29 │
└───────────────┴──────┴───┘
```

From the following examples:
### using args
 * `json2table name                    gender  ">age<=39"`
 * `json2table "name=/e[ ] (u|m)/ix"   gender  ">age"    `

### using `cols`
 * `sort_by=">age" cols=" name                gender  age<=39" json2table`
 * `               cols=" name                gender >age<=39" json2table`
 * `               cols="<name=/^m/i          gender  age"     json2table`
 * `               cols="<name=/e (u|m)/i     gender  age"     json2table`
 * `               cols="<name=/e[ ] (u|m)/ix gender  age"     json2table`

### using `sort_by`
 * `sort_by="        >age<=39" json2table  name                 gender   age     `
 * `sort_by="        >age"     json2table  name                 gender  "age<=39"`
 * `sort_by="<gender <age"     json2table  name                 gender  "age<=39"`
 * `sort_by="gender age"       json2table  name                 gender  "age<=39"`
 * `sort_by="gender age"       json2table "name=/e[ ] (u|m)/ix" gender   age     `


> [!IMPORTANT]
> Ensure to use proper escaping for filters and regex patterns within your shell commands for accurate results.

By implementing these improvements, `json2table` now supports more dynamic and complex data manipulations directly, making it a more powerful tool for JSON data processing.
